### PR TITLE
Ignore our own multicast frames

### DIFF
--- a/port/ethernetif.c
+++ b/port/ethernetif.c
@@ -200,6 +200,13 @@ ethernetif_input(int iface, struct pbuf *p)
     /* points to packet payload, which starts with an Ethernet header */
     ethhdr = p->payload;
 
+    /* Ignore our own multicast packets when they come back from the AP */
+    if ((ethhdr->dest.addr[0] & 0x01) /* multicast */ &&
+	!memcmp(ethhdr->src.addr, netif->hwaddr, ETH_HWADDR_LEN)) {
+	    pbuf_free(p);
+	    p = NULL;
+	    return;
+    }
     switch (htons(ethhdr->type))
     {
         /* IP or ARP packet? */


### PR DESCRIPTION
Multicast on WiFi generally works by sending the packet unicast to the AP, which then sends it back out to all stations (at a slow bitrate). Ignore our own frames; they were causing us to spam mDNS as we responded to our own queries, and they also break IPv6 Duplicate Address Detection.