### PR TITLE
Bump MEMP_NUM_SYS_TIMEOUT to fix mDNS on Legacy IP

### DIFF
--- a/port/lwipopts.h
+++ b/port/lwipopts.h
@@ -179,7 +179,7 @@
  * MEMP_NUM_SYS_TIMEOUT: the number of simulateously active timeouts.
  * (requires NO_SYS==0)
  */
-#define MEMP_NUM_SYS_TIMEOUT            LWIP_NUM_SYS_TIMEOUT_INTERNAL + 4
+#define MEMP_NUM_SYS_TIMEOUT            LWIP_NUM_SYS_TIMEOUT_INTERNAL + 10
 
 /**
  * MEMP_NUM_NETBUF: the number of struct netbufs.


### PR DESCRIPTION
In 2.2.0, mDNS needs ten extra timeouts. We didn't give it enough, which means it didn't respond on Legacy IP because the 'recent multicast' flag never got reset by the timer.

We probably ought to hook up LWIP_ASSERT so we actually see it.